### PR TITLE
Fix typo "features" under DevX Pod section

### DIFF
--- a/src/lib/components/index/fragments/devx-pod.svelte
+++ b/src/lib/components/index/fragments/devx-pod.svelte
@@ -7,7 +7,7 @@
 
 <ContentSection id="devx-pod" title="DevX Pod" annotation="listen" icon={Listen}>
 	<p slot="text" class="pt-x-small text-justify">
-		DevX Pod feature in-depth interviews with DevX experts. Hosts Pauline Narvas and Chris Weichel
+		DevX Pod features in-depth interviews with DevX experts. Hosts Pauline Narvas and Chris Weichel
 		speak with developer experience leaders to unpack the ins-and-outs of the field.
 	</p>
 	<div>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod.io/#https://github.com/gitpod-io/devx-community/pull/88"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

