### PR TITLE
Redirect all traffic to ona.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,9 +13,3 @@
   command = "npm run dev"
   targetPort = 5173
 
-[[redirects]]
-  from = "/*"
-  to = "https://ona.com"
-  status = 302
-  force = true
-

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,4 +9,10 @@
 [dev]
   command = "npm run dev"
   targetPort = 5173
-  
+
+[[redirects]]
+  from = "/*"
+  to = "https://ona.com"
+  status = 302
+  force = true
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = "build/"
 
+[build.environment]
+  NODE_VERSION = "20"
+
 [functions]
   directory = "src/functions"
   node_bundler = "esbuild"

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/*    https://ona.com    302!


### PR DESCRIPTION
Adds a 302 redirect in Netlify configuration to redirect all pages and sub-pages to https://ona.com.

## Changes
- Added `[[redirects]]` block to `netlify.toml` with `force = true` to ensure all traffic is redirected regardless of existing content